### PR TITLE
Add support for HDFS federation

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -41,7 +41,7 @@ func getClientForUser(t *testing.T, username string) *Client {
 		t.Fatal("Couldn't load ambient config", err)
 	}
 
-	options := ClientOptionsFromConf(conf)
+	options := DefaultClientOptionsFromConf(conf)
 	if options.Addresses == nil {
 		t.Fatal("Missing namenode addresses in ambient config")
 	}
@@ -149,7 +149,7 @@ func TestNewWithMultipleNodes(t *testing.T) {
 		t.Fatal("Couldn't load ambient config", err)
 	}
 
-	nns := conf.Namenodes()
+	nns := conf.DefaultNamenodes()
 
 	nns = append([]string{"localhost:100"}, nns...)
 	_, err = NewClient(ClientOptions{Addresses: nns, User: "gohdfs1"})

--- a/cmd/hdfs/main.go
+++ b/cmd/hdfs/main.go
@@ -187,7 +187,7 @@ func getClient(namenode string) (*hdfs.Client, error) {
 		return nil, fmt.Errorf("Problem loading configuration: %s", err)
 	}
 
-	options := hdfs.ClientOptionsFromConf(conf)
+	options := hdfs.DefaultClientOptionsFromConf(conf)
 	if namenode != "" {
 		options.Addresses = []string{namenode}
 	}

--- a/hadoopconf/hadoopconf_test.go
+++ b/hadoopconf/hadoopconf_test.go
@@ -19,7 +19,7 @@ func TestConfFallback(t *testing.T) {
 	conf, err := LoadFromEnvironment()
 	assert.NoError(t, err)
 
-	nns := conf.Namenodes()
+	nns := conf.DefaultNamenodes()
 	assert.NoError(t, err)
 	assert.EqualValues(t, conf2Namenodes, nns, "loading via HADOOP_CONF_DIR (testdata/conf2)")
 
@@ -28,7 +28,7 @@ func TestConfFallback(t *testing.T) {
 	conf, err = LoadFromEnvironment()
 	assert.NoError(t, err)
 
-	nns = conf.Namenodes()
+	nns = conf.DefaultNamenodes()
 	assert.NoError(t, err)
 	assert.EqualValues(t, confNamenodes, nns, "loading via HADOOP_HOME (testdata/conf)")
 


### PR DESCRIPTION
These changes now enforce proper HDFS configurations. Specifically:

  * Highly available (HA) clusters require 1. a nameservice in dfs.nameservices 2. namenode ids for that nameservice in dfs.ha.namenodes.NAMESERVICE 3. rpc addresses for those namenode ids in dfs.namenode.rpc-address.NAMESERVICE.NNID
  * Non-HA but federated clusters require
    1. a nameservice in dfs.nameservices
    2. an rpc address for the namenode in dfs.namenode.rpc-address.NAMESERVICE
  * Non-HA and non-federated clusters require 1. an rpc address for the namenode in dfs.namenode.rpc-address

HA and federated configuration takes precedence such that if a property like dfs.nameservices is present, default clients will not use a sole namenode rpc address defined by dfs.namenode.rpc-address alone.